### PR TITLE
Timing

### DIFF
--- a/src/ZwiftMemoryScanner.js
+++ b/src/ZwiftMemoryScanner.js
@@ -780,6 +780,18 @@ class ZwiftMemoryScanner {
      * @property {Object} playerData.units - Unit definitions for various measurements
      */
     extendPlayerStateData(playerData) {
+
+        if ((playerData?.timestamp) && (playerData.timestamp == (this._lastSeenTimestamp ?? 0))) {
+            if (this._lastSeenTimestampTime && Date.now() - this._lastSeenTimestampTime > 2*this._options.timeout) {
+              // if we have not seen a new timestamp in 2x the timeout, then we adjust the timestamp
+              playerData._timestamp = playerData.timestamp
+              playerData.timestamp = this._lastSeenTimestamp + (Date.now() - this._lastSeenTimestampTime)
+            }
+        } else {
+          this._lastSeenTimestamp = playerData.timestamp
+          this._lastSeenTimestampTime = Date.now()
+        }
+
         //
         if (playerData?.cadence_uHz >= 0) {
             playerData.cadence = Math.round(playerData?.cadence_uHz / 1000000 * 60)

--- a/src/examples/state.js
+++ b/src/examples/state.js
@@ -19,6 +19,7 @@ zmm.on('data', (playerdata) => {
         dataSeen.set(playerdata.packetInfo.type, playerdata);
         console.log('>> ', playerdata.packetInfo.type, playerdata);
     }
+    // console.log('>>', Date.now(), playerdata.timestamp, playerdata._timestamp ?? '')
 })
 
 let timeoutAfter = 180_000;
@@ -68,9 +69,10 @@ zmm.once('ready', () => {
     }
 
     try {
-        // zmm.start(['playerstate'])
-        zmm.start(['playerstate', 'playerprofile'])
+        zmm.start(['playerstate'])
+        // zmm.start(['playerstate', 'playerprofile'])
         // zmm.start(['playerstate', 'playerprofile'], { forceScan: true })
+        // zmm.start(['playerstate'], { timeout: 500,})
         // zmm.start(['playerstate'], { forceScan: true, multiPass: true,})
         // zmm.start(['playerstate'], { forceScan: true})
         // zmm.start(['playerprofile'], { forceScan: true })


### PR DESCRIPTION
Handle case where Zwift only updates timestamp once per second (when paused) by updating timestamp if it hasn't changed in 2 x timeout milliseconds. The original timestamp is saved as _timestamp